### PR TITLE
Fix infinite recursion when extracting nested types with cyclic nesting/inheritance

### DIFF
--- a/src/stubgen/extract_stubs.py
+++ b/src/stubgen/extract_stubs.py
@@ -225,27 +225,28 @@ def _extract_members[T: CWrapper](
 
     def get_parents(root: TypeInfo) -> list[TypeInfo]:
         parents: list[TypeInfo] = []
+        interfaces: list[TypeInfo] = []
         visited: set[str] = {type_key(root)}
         stack: list[TypeInfo] = [root]
         while stack:
             current: TypeInfo = stack.pop()
             base_type: TypeInfo | None = current.BaseType
-            if base_type is None:
-                continue
-            if type_key(base_type) in visited:
-                continue
 
-            parents.append(base_type)
-            stack.append(base_type)
-            visited.add(type_key(base_type))
+            if base_type is not None:
+                k = type_key(base_type)
+                if k not in visited:
+                    parents.append(base_type)
+                    stack.append(base_type)
+                    visited.add(k)
 
             for interface in current.GetInterfaces():
-                if type_key(interface) in visited:
-                    continue
-                parents.append(interface)
-                stack.append(interface)
-                visited.add(type_key(interface))
-        return parents
+                k = type_key(interface)
+                if k not in visited:
+                    interfaces.append(interface)
+                    stack.append(interface)
+                    visited.add(k)
+
+        return parents + interfaces
 
     if skip_parents:
         return found

--- a/src/stubgen/extract_stubs.py
+++ b/src/stubgen/extract_stubs.py
@@ -212,15 +212,39 @@ def _extract_members[T: CWrapper](
     binding_flags: BindingFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static
     found: dict[str, T] = {obj.unique_name: obj for obj in member_func(type_info, binding_flags)}
 
-    def get_parents(type_info: TypeInfo) -> list[TypeInfo]:
+    def type_key(t: TypeInfo) -> str:
+        assembly_qualified_name = getattr(t, "AssemblyQualifiedName", None)
+        if assembly_qualified_name:
+            return str(assembly_qualified_name)
+        full_name = getattr(t, "FullName", None)
+        if full_name:
+            return str(full_name)
+        namespace = getattr(t, "Namespace", None)
+        name = getattr(t, "Name", None)
+        return f"{namespace}.{name}"
+
+    def get_parents(root: TypeInfo) -> list[TypeInfo]:
         parents: list[TypeInfo] = []
-        if type_info.BaseType is not None:
-            parents.append(type_info.BaseType)
-            parents.extend(get_parents(type_info.BaseType))
-        interface: TypeInfo
-        for interface in type_info.GetInterfaces():
-            parents.append(interface)
-            parents.extend(get_parents(interface))
+        visited: set[str] = {type_key(root)}
+        stack: list[TypeInfo] = [root]
+        while stack:
+            current: TypeInfo = stack.pop()
+            base_type: TypeInfo | None = current.BaseType
+            if base_type is None:
+                continue
+            if type_key(base_type) in visited:
+                continue
+
+            parents.append(base_type)
+            stack.append(base_type)
+            visited.add(type_key(base_type))
+
+            for interface in current.GetInterfaces():
+                if type_key(interface) in visited:
+                    continue
+                parents.append(interface)
+                stack.append(interface)
+                visited.add(type_key(interface))
         return parents
 
     if skip_parents:
@@ -383,7 +407,7 @@ def extract_class(info: TypeInfo) -> CClass:
         properties=_extract_members(info, _get_properties),
         methods=_get_methods(info),
         events=_extract_members(info, _get_events),
-        nested_types=_extract_members(info, _get_nested),
+        nested_types=_extract_members(info, _get_nested, True),
     )
 
 

--- a/test/TestLib/ExtractCyclicDependencies.cs
+++ b/test/TestLib/ExtractCyclicDependencies.cs
@@ -1,0 +1,8 @@
+namespace TestLib;
+
+public class SuperCat : CatBase { }
+
+public class CatBase
+{
+    public class UltraCat : SuperCat { }
+}


### PR DESCRIPTION
### Problem:
Stub generation can enter infinite recursion when a nested type participates in an inheritance chain that points back to its declaring type. 

### Minimal repro:
```
public class SuperCat : CatBase { }

public class CatBase
{
    public class UltraCat : SuperCat { }
}
```
In this pattern, inheriting nested types from base classes can cause a nested type to appear in its own nested_types list, leading to recursion/stack overflow.

### Fix
Add cycle protection to parent traversal using a visited set in `get_parents()`
